### PR TITLE
Fix theme wiring so minima is actually used + overrides

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
   <title>Baby Steps</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta charset="utf-8">
-  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/app.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css">
 </head>
 
 <body>

--- a/_sass/app.scss
+++ b/_sass/app.scss
@@ -1,5 +1,3 @@
----
----
 @import url("https://fonts.googleapis.com/css?family=Zilla+Slab:400,700");
 @import url("https://fonts.googleapis.com/css?family=DM-Sans:400,700,800");
 @import url("https://fonts.googleapis.com/css2?family=DM+Mono:wght@300&display=swap");

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -3,6 +3,8 @@
 ---
 @charset "utf-8";
 
+@import "app";
+
 // Our variables
 $base-font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 $base-font-size:   16px;

--- a/nikomatsakis-babysteps-theme.gemspec
+++ b/nikomatsakis-babysteps-theme.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "nikomatsakis-babysteps-theme"
-  spec.version       = "0.1.8"
+  spec.version       = "0.1.9"
   spec.authors       = ["Niko Matsakis"]
   spec.email         = ["niko@alum.mit.edu"]
 


### PR DESCRIPTION
First off, thank you for the awesome blog!  Long time reader, first time contributor here :P.  I hope this PR is helpful, and my sincere apologies if this is unwelcome in any way.

I was reading a recent post on my Android phone and became disgruntled enough with the weird overflow scrolling behavior that I decided to check out _why_ your theme was "unhappy".  After a bit of learning about Jekyll/SCSS/etc. I figured out your theme was including `assets/css/app.scss` while all your overrides / theme inclusion / etc. were in a `main.scss` file which was totally ignored.

Now, this version is probably not _exactly_ what you want, but it *does* fix the issues with overflow, syntax highlighting / formatting not working, etc.  It even fixes the title sizing on mobile!

Note that I believe [the apparent override `main.scss`](https://github.com/nikomatsakis/babysteps/blob/master/babysteps/assets/main.scss) file over on https://github.com/nikomatsakis/babysteps is still ignored.

Screenshots before this PR:
![Screen Shot 2022-09-26 at 16 52 44](https://user-images.githubusercontent.com/101064/192378209-b3b93e67-17e7-4dde-998a-c12c02a1d8dc.png)
![Screen Shot 2022-09-26 at 16 50 18](https://user-images.githubusercontent.com/101064/192378133-99a2a64e-ff8a-46f7-b3ce-128679bb4e73.png)


Screenshots after this PR:
![Screen Shot 2022-09-26 at 16 51 10](https://user-images.githubusercontent.com/101064/192378119-3b219567-cdec-4662-a7c9-8587d87496b8.png)
![Screen Shot 2022-09-26 at 16 51 27](https://user-images.githubusercontent.com/101064/192378111-d50ace75-7664-46ac-a390-bac8c0160729.png)

